### PR TITLE
Json data column to object datatype

### DIFF
--- a/embulk-output-elasticsearch_using_url.gemspec
+++ b/embulk-output-elasticsearch_using_url.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'elasticsearch'
+  spec.add_dependency 'json'
   spec.add_development_dependency 'embulk', ['>= 0.8.16']
   spec.add_development_dependency 'bundler', ['>= 1.10.6']
   spec.add_development_dependency 'rake', ['>= 10.0']


### PR DESCRIPTION
Add new parameter in `array_column`.
These parameter parse json string to Elasticsearch object field data.

### Usage
- **name** target json string column name.(existing) 
- **parse_json** parse json column to object data. (true or not)
- **error_skip** when parse error, skip column or stop.(true or not)
### Example
- setting:
    - name: json_col
    - parse_json: true
    - error_skip: true
- in:
```
+-----------+---------------------------------+
| id:string |                 json_col:string |
+-----------+---------------------------------+
| "hoge"    | {"region":"kansai","area":"27"} |
| "fuga"    | {"region":"kanto","area":"13"}} | * parsing fail
+-----------+---------------------------------+
```
- out:
```
    "hits": [
      {
        "_source": {
          "id" : "hoge"
          "json_col": {
            "region": "kansai",
            "area": "27"
          }
        }
      },
      {
        "_source": {
          "id" : "fuga"
          "json_col": null
        }
      }
    ]
```